### PR TITLE
Fix Part Costs

### DIFF
--- a/GameData/UmbraSpaceIndustries/LifeSupport/Parts/Greenhouse.cfg
+++ b/GameData/UmbraSpaceIndustries/LifeSupport/Parts/Greenhouse.cfg
@@ -8,7 +8,7 @@ PART
 	node_stack_bottom = 0,-.25,0,0,-1,0
 	TechRequired = survivability
 	entryCost = 1000
-	cost = 100
+	cost = 1850
 	category = Utility
 	subcategory = 0
 	title = Nom-O-Matic 5000	

--- a/GameData/UmbraSpaceIndustries/LifeSupport/Parts/JumboGreenhouse.cfg
+++ b/GameData/UmbraSpaceIndustries/LifeSupport/Parts/JumboGreenhouse.cfg
@@ -8,7 +8,7 @@ PART
 	node_stack_bottom = 0,-.25,0,0,-1,0
 	TechRequired = survivability
 	entryCost = 1000
-	cost = 5000
+	cost = 16250
 	category = Utility
 	subcategory = 0
 	title = Nom-O-Matic 25000	

--- a/GameData/UmbraSpaceIndustries/LifeSupport/Parts/MiniPak_01.cfg
+++ b/GameData/UmbraSpaceIndustries/LifeSupport/Parts/MiniPak_01.cfg
@@ -7,7 +7,7 @@ PART
 	node_attach = 0,0,.15,0,0,-1
 	TechRequired = survivability
 	entryCost = 1000
-	cost = 100
+	cost = 1600
 	category = Utility
 	subcategory = 0
 	title = Life Support MiniPak (Supplies)

--- a/GameData/UmbraSpaceIndustries/LifeSupport/Parts/MiniPak_02.cfg
+++ b/GameData/UmbraSpaceIndustries/LifeSupport/Parts/MiniPak_02.cfg
@@ -7,7 +7,7 @@ PART
 	node_attach = 0,0,.15,0,0,-1
 	TechRequired = survivability
 	entryCost = 1000
-	cost = 100
+	cost = 600
 	category = Utility
 	subcategory = 0
 	title = Life Support MiniPak (Fertilizer)

--- a/GameData/UmbraSpaceIndustries/LifeSupport/Parts/MiniPak_03.cfg
+++ b/GameData/UmbraSpaceIndustries/LifeSupport/Parts/MiniPak_03.cfg
@@ -7,7 +7,7 @@ PART
 	node_attach = 0,0,.15,0,0,-1
 	TechRequired = survivability
 	entryCost = 1000
-	cost = 100
+	cost = 350
 	category = Utility
 	subcategory = 0
 	title = Life Support MiniPak (Mulch)

--- a/GameData/UmbraSpaceIndustries/LifeSupport/Parts/Tank_125.cfg
+++ b/GameData/UmbraSpaceIndustries/LifeSupport/Parts/Tank_125.cfg
@@ -18,7 +18,7 @@ node_stack_bottom = 0.0, -.25, 0.0, 0.0, -1.0, 0.0, 1
 
 TechRequired = survivability
 entryCost = 3000
-cost = 500
+cost = 8025
 category = Utility
 subcategory = 0
 title = Life Support Tank (1.25)

--- a/GameData/UmbraSpaceIndustries/LifeSupport/Parts/Tank_250.cfg
+++ b/GameData/UmbraSpaceIndustries/LifeSupport/Parts/Tank_250.cfg
@@ -1,4 +1,4 @@
-PART
+	PART
 {
 name = LS_Tank_250
 module = Part
@@ -18,7 +18,7 @@ node_stack_bottom = 0.0, -.5, 0.0, 0.0, -1.0, 0.0, 1
 
 TechRequired = survivability
 entryCost = 3000
-cost = 1000
+cost = 68875
 category = Utility
 subcategory = 0
 title = Life Support Tank (2.5)

--- a/GameData/UmbraSpaceIndustries/LifeSupport/Parts/Tank_375.cfg
+++ b/GameData/UmbraSpaceIndustries/LifeSupport/Parts/Tank_375.cfg
@@ -17,7 +17,7 @@ node_stack_bottom = 0.0, -.75, 0.0, 0.0, -1.0, 0.0, 1
 
 TechRequired = survivability
 entryCost = 3000
-cost = 1500
+cost = 227250
 category = Utility
 subcategory = 0
 title = Life Support Tank (3.75)


### PR DESCRIPTION
Assuming the part cost in the configs were meant to be the empty containers/converters, recalculate the part cost with full ressources, because that's what the KSP part costs are actually supposed to be.