### PR TITLE
Remove ReplacementParts input ressource from MPL

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/LSModule.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/LSModule.cfg
@@ -96,11 +96,6 @@
 			ResourceName = ElectricCharge
 			Ratio = 1
 		}
-		INPUT_RESOURCE
-		{
-			ResourceName = ReplacementParts
-			Ratio = 0.00001
-		}	
 	}
 
 	MODULE


### PR DESCRIPTION
Follow the removal of the the ReplacementParts requirement in MKS/OKS.

This fixes #78 , and (including previous changes) #72 .