### PR TITLE
Calculate supply consumption by kerbals not just by part

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 obj/
 bin/
+.vs
 *.cache
+*.user
 *.zip

--- a/Source/USILifeSupport/ModuleLifeSupport.cs
+++ b/Source/USILifeSupport/ModuleLifeSupport.cs
@@ -199,7 +199,12 @@ namespace LifeSupport
                                     k.CurrentVesselId = part.vessel.id.ToString();
                                 }
                             }
-                            isGrouchyHab = CheckHabSideEffects(k, v);
+                            if ((LifeSupportManager.isVet(k.KerbalName)
+                                            ? LifeSupportSetup.Instance.LSConfig.NoHomeEffectVets
+                                            : LifeSupportSetup.Instance.LSConfig.NoHomeEffect) > 0)
+                            {
+                                isGrouchyHab = CheckHabSideEffects(k, v);
+                            }
                         }
                         #endregion - Crew
                         //Second - Supply

--- a/Source/USILifeSupport/ModuleLifeSupport.cs
+++ b/Source/USILifeSupport/ModuleLifeSupport.cs
@@ -81,8 +81,17 @@ namespace LifeSupport
             }
         }
 
+        private int firstFixedUpdate = 1;
         public void FixedUpdate()
         {
+            // When switching scenes to a vessel FixedUpdate will get called before the scenario is restored from configuration.
+            // In this case changes to the vessel will remain but changes to the scenario will get undone (causing over-consumption
+            // of supplies). Delaying processing prevents that from happening.
+            if (firstFixedUpdate > 0)
+            {
+                firstFixedUpdate = 0;
+                return;
+            }
             try
             {
                 bool isLongLoop = false;


### PR DESCRIPTION
Changed supply consumption to be based on the per-kerbal stats saved in the LifeSupportScenario instead of consuming supplies based on a lastUpdateTime on the part.