### PR TITLE
Update CTT.cfg for Inline Greenhouse

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/CTT.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/CTT.cfg
@@ -6,3 +6,7 @@
 {
     @TechRequired = hydroponics
 }
+@PART[USILS_Greenhouse_IL]:NEEDS[CommunityTechTree]
+{
+    @TechRequired = hydroponics
+}


### PR DESCRIPTION
Community Tech Tree 2.4

Suggested change to add to hydroponics node alongside the equivalent greenhouse.

Currently the Nom-o-matic 25000-I appears in the default node (survivability) when using CTT, making it available earlier than both of the other greenhouses.