### PR TITLE
Fix #144 Life Support Status window not showing in Tracking Station

### DIFF
--- a/Source/USILifeSupport/LifeSupportMonitor.cs
+++ b/Source/USILifeSupport/LifeSupportMonitor.cs
@@ -14,11 +14,21 @@ namespace LifeSupport
 {
     [KSPAddon(KSPAddon.Startup.Flight, false)]
     public class LifeSupportMonitor_Flight : LifeSupportMonitor
-    { }
+    {
+        protected override bool IsActive()
+        {
+            return HighLogic.LoadedSceneIsFlight;
+        }
+    }
 
     [KSPAddon(KSPAddon.Startup.TrackingStation, false)]
     public class LifeSupportMonitor_TStation : LifeSupportMonitor
-    { }
+    {
+        protected override bool IsActive()
+        {
+            return HighLogic.LoadedScene == GameScenes.TRACKSTATION;
+        }
+    }
 
 
     public class LifeSupportMonitor : MonoBehaviour
@@ -64,7 +74,7 @@ namespace LifeSupport
         {
             if (!renderDisplay)
                 return;
-            if (!HighLogic.LoadedSceneIsFlight)
+            if (!IsActive())
                 return;
 
 
@@ -73,6 +83,11 @@ namespace LifeSupport
                 //preDrawQueue
             }
             Ondraw();
+        }
+
+        protected virtual bool IsActive()
+        {
+            return false;
         }
 
 


### PR DESCRIPTION
Hello,

This should fix issue #144 where the Life Support Status window does not show while in the Tracking Station. It looks like that use case was overlooked in e075db81cae574af42911b3472aaad61de2bc34f when adding a scene-based check.

I tested it on my computer, and the window appears as expected both in the tracking station and in flight.

One last thing : I would normally have made the base LifeSupportMonitor class abstract, but I'm not sure if it fits your usual coding style so I did not; tell me if you'd like me to change that.

Also, thanks for all the mods!