### PR TITLE
Add 2.5m attachment node to Nom-O-Matic 25000

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/Parts/Greenhouse_Cupola.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/Parts/Greenhouse_Cupola.cfg
@@ -6,6 +6,7 @@ PART
 	rescaleFactor = 1
 	node_attach = 0,-.15,0,0,-1,0
 	node_stack_bottom = 0,-.25,0,0,-1,0
+	node_stack_250bottom = 0,0,0,0,-1,0,2
 	TechRequired = survivability
 	entryCost = 1000
 	cost = 5000


### PR DESCRIPTION
The Nom-O-Matic 25000 is a 2.5m part that tapers to a 1.25m attachment point, which makes it awkward to connect to another 2.5m part.  This change adds a 2.5m attachment node behind the 1.25m one, so it can be connected properly to parts of either diameter.  (This is similar to the multiple attachment nodes on the MKS Tundra modules, though without the fancy conditional visibility on the tapered part.)