### PR TITLE
Fix recyclers not working during catchup

### DIFF
--- a/Source/USILifeSupport/LifeSupportManager.cs
+++ b/Source/USILifeSupport/LifeSupportManager.cs
@@ -321,9 +321,9 @@ namespace LifeSupport
                 var r = recList[i];
                 if (r.RecyclerIsActive && r.IsActivated)
                 {
-                    if (r.AdjustedRecyclePercent > recyclerCap)
-                        recyclerCap = r.AdjustedRecyclePercent;
-                    var recPercent = r.AdjustedRecyclePercent;
+                    if (r.RecyclePercent > recyclerCap)
+                        recyclerCap = r.RecyclePercent;
+                    var recPercent = r.RecyclePercent;
                     if (r.CrewCapacity < crewCount)
                         recPercent *= r.CrewCapacity/(float) crewCount;
 
@@ -344,9 +344,9 @@ namespace LifeSupport
                     var r = subRecList[x];
                     if (r.IsActivated && r.RecyclerIsActive)
                     {
-                        if (r.AdjustedRecyclePercent > recyclerCap)
-                            recyclerCap = r.AdjustedRecyclePercent;
-                        var recPercent = r.AdjustedRecyclePercent;
+                        if (r.RecyclePercent > recyclerCap)
+                            recyclerCap = r.RecyclePercent;
+                        var recPercent = r.RecyclePercent;
                         if (r.CrewCapacity < crewCount)
                             recPercent *= r.CrewCapacity / (float)crewCount;
 
@@ -440,9 +440,9 @@ namespace LifeSupport
                 if (!mod.RecyclerIsActive && !HighLogic.LoadedSceneIsEditor)
                     continue;
 
-                if (mod.AdjustedRecyclePercent > recyclerCap)
-                    recyclerCap = mod.AdjustedRecyclePercent;
-                var recPercent = mod.AdjustedRecyclePercent;
+                if (mod.RecyclePercent > recyclerCap)
+                    recyclerCap = mod.RecyclePercent;
+                var recPercent = mod.RecyclePercent;
                 if (mod.CrewCapacity < crewCount)
                     recPercent *= mod.CrewCapacity / (float)crewCount;
 

--- a/Source/USILifeSupport/LifeSupportMonitor_Editor.cs
+++ b/Source/USILifeSupport/LifeSupportMonitor_Editor.cs
@@ -375,7 +375,7 @@ namespace LifeSupport
                             var recycler = recyclers[x];
                             GUILayout.BeginHorizontal();
                             GUILayout.Label(CTag(recycler.part.partInfo.title, partColor), _labelStyle, GUILayout.Width(c1));
-                            GUILayout.Label(CTag(((int)(recycler.AdjustedRecyclePercent * 100)).ToString(), textColor), _labelStyle, GUILayout.Width(c2));
+                            GUILayout.Label(CTag(((int)(recycler.RecyclePercent * 100)).ToString(), textColor), _labelStyle, GUILayout.Width(c2));
                             GUILayout.Label(CTag(recycler.CrewCapacity.ToString(), textColor), _labelStyle, GUILayout.Width(c3));
                             GUILayout.EndHorizontal();
                         }

--- a/Source/USILifeSupport/ModuleLifeSupportRecycler.cs
+++ b/Source/USILifeSupport/ModuleLifeSupportRecycler.cs
@@ -15,23 +15,6 @@ namespace LifeSupport
         [KSPField(isPersistant = true)] 
         public bool RecyclerIsActive = false;
 
-        private float _adjPercent = 1f;
-        public float AdjustedRecyclePercent
-        {
-            get
-            {
-                if (!HighLogic.LoadedSceneIsFlight)
-                    return RecyclePercent;
-                if (!RecyclerIsActive || !IsActivated)
-                    _adjPercent = 0f;
-                return _adjPercent;
-            }
-            set
-            {
-                _adjPercent = value;
-            }
-        }
-
         protected override void PreProcessing()
         {
             base.PreProcessing();
@@ -42,7 +25,6 @@ namespace LifeSupport
         {
             base.PostProcess(result, deltaTime);
             RecyclerIsActive = result.TimeFactor > ResourceUtilities.FLOAT_TOLERANCE;
-            AdjustedRecyclePercent = (float)(RecyclePercent*(result.TimeFactor/deltaTime));
         }
         
         public override string GetInfo()
@@ -50,7 +32,7 @@ namespace LifeSupport
             var output = new StringBuilder();
             output.Append(base.GetInfo());
             output.Append(Environment.NewLine);
-            output.Append(String.Format("Recycler Percent: {0}%", AdjustedRecyclePercent * 100));
+            output.Append(String.Format("Recycler Percent: {0}%", RecyclePercent * 100));
             output.Append(Environment.NewLine);
             output.Append(String.Format("Crew Affected: {0}", CrewCapacity));
             output.Append(Environment.NewLine);

--- a/Source/USILifeSupport/ModuleLifeSupportSystem.cs
+++ b/Source/USILifeSupport/ModuleLifeSupportSystem.cs
@@ -524,11 +524,11 @@ namespace LifeSupport
             //Two recipes are executed.  One for EC, one for Supplies.
             var recipe = new ConversionRecipe();
             var numCrew = _currentCrew;
-            var recPercent = VesselStatus.RecyclerMultiplier;          
+            var recMult = VesselStatus.RecyclerMultiplier;   
             var supAmount = LifeSupportScenario.Instance.settings.GetSettings().SupplyAmount;
             var scrapAmount = LifeSupportScenario.Instance.settings.GetSettings().WasteAmount;
-            var supRatio = supAmount * numCrew * recPercent;
-            var mulchRatio = scrapAmount * numCrew * recPercent;
+            var supRatio = supAmount * numCrew * recMult;
+            var mulchRatio = scrapAmount * numCrew * recMult;
             recipe.Inputs.Add(new ResourceRatio { FlowMode = ResourceFlowMode.ALL_VESSEL, Ratio = supRatio, ResourceName = "Supplies", DumpExcess = true });
             recipe.Outputs.Add(new ResourceRatio { FlowMode = ResourceFlowMode.ALL_VESSEL, Ratio = mulchRatio, ResourceName = "Mulch", DumpExcess = true });
             return recipe;


### PR DESCRIPTION
Should fix #208.

After investigations, I found out what happens: GenerateSupplyRecipe() in the vessel module is using VesselStatus.RecyclerMultiplier, which is regularly updated from the Recycler module's AdjustedRecyclePercent field. The problem is that AdjustedRecyclePercent defaults to 1 (which should mean 100% in my opinion but is considered by later code as an error value equivalent to 0). And AdjustedRecyclePercent is filled from RecyclePercent in PostProcess(). But during refocus/catchup, PostProcess() does not seem called, until a few seconds have passed.

This could be considered a bug in KSP itself (I don't know when PostProcess is supposed to be called), but anyway, since recyclers don't work through converter mechanics  (except for EC consumption) and the percent is just a variable that is set for other modules to use, I simplified assuming the "adjusted percent" is not needed (maybe it was introduced at a time when recyclers were meant to fully work as a true converter).