### PR TITLE
Added CLS passable = true to LgRecycler.cfg

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/Parts/LgRecycler.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/Parts/LgRecycler.cfg
@@ -45,6 +45,13 @@ PART
 			ResourceName = ElectricCharge
 			Ratio = 18.75
 		}
-	}	
+	}
+	
+	MODULE
+ 	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
+
 	
 }


### PR DESCRIPTION
This pull  would allow the RT-5000 Recycling Module to be passable when using Connected Living Space.

My thinking is that I just don't see why there wouldn't be a tube in the middle of it for Kerbals to climb through on a space station. Also, the current art has a nice core that looks like it could be a crew tube.